### PR TITLE
Minor PR: Update process.py to fix non-stream text generation stuck bug.

### DIFF
--- a/src/process.py
+++ b/src/process.py
@@ -76,19 +76,18 @@ def Request(modele_rkllm):
                         time.sleep(0.005)
 
                         thread_modele.join(timeout=0.005)
-                        threadFinish = not thread_modele.is_alive()
-                        llmResponse["usage"]["completion_tokens"] = count
-                        llmResponse["usage"]["total_tokens"] += 1
+                    threadFinish = not thread_modele.is_alive()
 
-                    total = time.time() - start
-
-                    llmResponse["usage"]["tokens_per_second"] = count / total
-                    llmResponse["choices"] = [{
-                        "role": "assistant",
-                        "content": sortie_rkllm,
-                        "logprobs": None,
-                        "finish_reason": "stop"
-                    }]
+                total = time.time() - start
+                llmResponse["choices"] = [{
+                    "role": "assistant",
+                    "content": sortie_rkllm,
+                    "logprobs": None,
+                    "finish_reason": "stop"
+                }]
+                llmResponse["usage"]["total_tokens"] = count + llmResponse["usage"]["prompt_tokens"]
+                llmResponse["usage"]["completion_tokens"] = count
+                llmResponse["usage"]["tokens_per_second"] = count / total
                 return jsonify(llmResponse), 200
 
             else:


### PR DESCRIPTION
I found a bug that makes Rkllama stuck after non-streamed text generation completes.
Rkllama doesn't return any results, even though the RKLLM library finished the text generation process.

This is mainly because the code checks for `threadFinish = not thread_modele.is_alive()` inside the inner loop (`while len(variables.global_text) > 0`). So when RKLLM no longer generates any object, the outer loop still continues, making an infinite loop because the inner loop will never be executed since.

The solution is to unindent that line of code so it will be executed in the outer loop.

Also with this merge request, I also calculate statistics such as Token-Per-Second outside of any loop, so it will only be calculated once. That is because this is a non-streamed request, so the response will be returned only once, unlike the streamed one.