### PR TITLE
CPU selection

### DIFF
--- a/rkllama.ini
+++ b/rkllama.ini
@@ -1,3 +1,3 @@
 [server]
-port = 8081
+port = 8080
 

--- a/server.sh
+++ b/server.sh
@@ -5,7 +5,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RESET='\033[0m'
 
-CPU_MODEL=""
+# Default values
 PORT=8080
 
 # Miniconda installation path
@@ -54,14 +54,22 @@ select_cpu_model() {
     echo -e "${GREEN}Selected CPU model: $CPU_MODEL${RESET}"
 }
 
-# Extract the CPU model if not defined in the environment
+# First check if CPU_MODEL is set in the environment
 if [ -z "$CPU_MODEL" ]; then
+  # Try to extract the CPU model from cpuinfo if not defined in environment
   CPU_MODEL=$(grep -i "cpu model" /proc/cpuinfo | head -n 1 | sed 's/.*Rockchip \(RK[0-9]*\).*/\1/' | tr '[:upper:]' '[:lower:]')
   echo "CPU_MODEL: $CPU_MODEL"
 fi
 
+# If still not detected, prompt for selection (only in interactive mode)
 if [ -z "$CPU_MODEL" ]; then
-  select_cpu_model
+  # Check if we're running in a container (non-interactive)
+  if [ -f "/.dockerenv" ]; then
+    echo -e "${YELLOW}Running in Docker without CPU_MODEL set. Defaulting to rk3588.${RESET}"
+    CPU_MODEL="rk3588"
+  else
+    select_cpu_model
+  fi
 fi
 
 python3 ~/RKLLAMA/server.py --target_platform "$CPU_MODEL" --port "$PORT"


### PR DESCRIPTION
This pull request includes updates to the server configuration and startup script to improve flexibility and default settings. The most important changes setting default values in the script, and enhancing CPU model detection.

Updates to server configuration:

* [`rkllama.ini`](diffhunk://#diff-e9756ab56f97af210d85b8b670b1bf36527a162ebb9cc63cecae2ee7c0bc423dL2-R2): Changed the server port from 8081 to 8080 due to other references being 8080

Enhancements to startup script:

* [`server.sh`](diffhunk://#diff-14d1967cdbd3938fb362411b147b4e44ab53b6a45a2c11a6bdd0c0d3c1658e54L57-R73): Improved CPU model detection by first checking if `CPU_MODEL` is set in the environment, extracting it from `cpuinfo` if not defined, and providing a default value when running in a Docker container.

Fixes #15 #13 update to #14 