### PR TITLE
fix: optimize inference performance by fixing token processing loop

### DIFF
--- a/src/rkllama/api/worker.py
+++ b/src/rkllama/api/worker.py
@@ -179,19 +179,19 @@ def run_rkllm_worker(name, task_queue: Queue, result_queue: Queue, model_path, m
                 while not thread_finished:
                     tokens_processed = False
                     while len(global_text) > 0:
-                        tokens_processed = False
                         token = global_text.pop(0)
                         result_queue.put(token)
+                        tokens_processed = True
 
-                    # Update status of the thread    
-                    thread_model.join(timeout=0.005)
+                    # Update status of the thread
+                    thread_model.join(timeout=0.001)
                     thread_finished = not thread_model.is_alive()
                     
-                    # If inference not started yet, wait some time to start.
-                    if not tokens_processed:
-                        time.sleep(0.01)
+                    # Only sleep if no tokens were processed and thread is still alive
+                    if not tokens_processed and not thread_finished:
+                        time.sleep(0.001)
 
-                # CLear the cache after inference
+                # Clear the cache after inference
                 model_rkllm.clear_cache()
 
                 # Send final signal of the inference


### PR DESCRIPTION
This PR is an attempt at addressing this issue https://github.com/NotPunchnox/rkllama/issues/54

- Fixed tokens_processed flag logic to properly track token processing
- Reduced sleep delay from 10ms to 1ms for better responsiveness
- Optimized thread synchronization timeout from 5ms to 1ms
- Only sleep when no tokens are processed AND thread is still alive
- Eliminates systematic delays that were causing slow inference compared to rknn-llm

P.S. this is a patch. the actual solution would be using asyncio (uses epoll interally on linux) instead of threads to handle queues.
this avoids CPU locking