### PR TITLE
Support for local tokenizer. Tokenizer only download for the first time inside models directory (Issue #104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RKLLama: LLM Server and Client for Rockchip 3588/3576
 
-### [Version: 0.0.56](#New-Version)
+### [Version: 0.0.57](#New-Version)
 
 Video demo ( version 0.0.1 ):
 
@@ -256,7 +256,6 @@ This will automatically download the specified model file and prepare it for use
     HUGGINGFACE_PATH="huggingface_repository"
     SYSTEM="Your system prompt"
     TEMPERATURE=1.0
-    TOKENIZER="path-to-tokenizer"
     ```
 
    Example directory structure:
@@ -267,7 +266,7 @@ This will automatically download the specified model file and prepare it for use
            └── TinyLlama-1.1B-Chat-v1.0.rkllm
    ```
 
-   *You must provide a link to a HuggingFace repository to retrieve the tokenizer and chattemplate. An internet connection is required for the tokenizer initialization (only once), and you can use a repository different from that of the model as long as the tokenizer is compatible and the chattemplate meets your needs.*
+   *You must provide a link to a HuggingFace repository to retrieve the tokenizer and chattemplate. An internet connection is required for the tokenizer initialization (only once), and you can use a repository different from that of the model as long as the tokenizer is compatible and the chattemplate meets your needs. Tokenizer gets downloaded for the first time in the models directory*
 
 
 ### **For Multimodal Encoder Model (.rknn) Installation**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rkllama"
-version = "0.0.56"
+version = "0.0.57"
 authors = [
     { name="NotPunchnox", email="punchnoxpro@gmail.com" },
     { name="TomJacobsUK", email="tom@tomjacobs.co.uk" },


### PR DESCRIPTION
**_First time download:_**
<img width="1121" height="101" alt="image" src="https://github.com/user-attachments/assets/dd0f11c2-db13-40ef-bbdc-366b4e42404b" />


**_When already exists:_**
<img width="660" height="26" alt="image" src="https://github.com/user-attachments/assets/ba136353-730e-4dfc-b251-88f926ebe229" />

_**Final directory structure for a model after tokenizer download:**_

<img width="318" height="184" alt="image" src="https://github.com/user-attachments/assets/e47b5de6-6119-4a8c-abeb-b618cade64cf" />
