### PR TITLE
feat: /api/rerank endpoint + concurrent multi-model serving + KV cache fix + image gen fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ A server to run and interact with LLM models optimized for Rockchip RK3588(S) an
    * `/api/ps`
    * `/api/tags`
    * `/api/embed` (and legacy `/api/embeddings`)
+   * `/api/rerank`
    * `/api/version` 
    * `/api/pull` 
 - **Partial OpenAI API compatibility** - Support for:
    * `/v1/completions`
    * `/v1/chat/completions`
    * `/v1/embeddings`
+   * `/v1/rerank`
    * `/v1/images/generations`
    * `/v1/audio/speech`
    * `/v1/audio/transcriptions`
@@ -59,6 +61,8 @@ A server to run and interact with LLM models optimized for Rockchip RK3588(S) an
 - **Pull models directly from Huggingface.**
 - **Include a API REST with documentation.**
 - **Listing available models.**
+- **Reranking** - Logit-based cross-encoder scoring on NPU via `/api/rerank` and `/v1/rerank` endpoints.
+- **Per-model locking** - Preload multiple models with `--preload model1,model2,model3` for concurrent multi-model NPU serving without blocking.
 - **Multiples RKLLM and RKNN models running in memory simultaniusly (parallels executions between distintct models in stream mode, FIFO if non stream)**
 - **Dynamic loading and unloading of models:**
     * Load the model after new request (if not in memory already)
@@ -185,6 +189,25 @@ Then start chatting *( **verbose mode**: display statistics )*
 
 *In version `0.0.60`, the verbose command returns this information:*
 ![Image](./documentation/ressources/verbose-chat.png)
+
+## Reranking
+
+RKLLama supports logit-based cross-encoder reranking on the NPU, useful for RAG pipelines. Documents are truncated to 14,000 characters for optimal NPU speed.
+
+```bash
+curl -X POST http://localhost:8080/api/rerank \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "What is the capital of France?",
+    "documents": [
+      {"text": "Paris is the capital of France."},
+      {"text": "Berlin is the capital of Germany."}
+    ],
+    "model": "qwen3-reranker-0.6b"
+  }'
+```
+
+The OpenAI-compatible endpoint `/v1/rerank` is also available with the same request format.
 
 ## Tool Calling Quick Start
 

--- a/documentation/api/english.md
+++ b/documentation/api/english.md
@@ -393,7 +393,69 @@ For complete documentation, see the [Tool Calling Guide](./tools.md).
 
 ---
 
-### **8. GET /**
+### **8. POST /api/rerank**
+#### **Description**
+Reranks a list of documents against a query using logit-based cross-encoder scoring on the RK3588 NPU. Also available at `/v1/rerank`. Documents are truncated to 14,000 characters for optimal NPU speed.
+
+#### **Request**
+```http
+POST /api/rerank
+Content-Type: application/json
+```
+
+##### **Parameters**
+```json
+{
+  "query": "search query",
+  "documents": [
+    {"text": "first document text"},
+    {"text": "second document text"}
+  ],
+  "model": "qwen3-reranker-0.6b"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `query` | string | Yes | The search query to rank documents against |
+| `documents` | array | Yes | List of objects with a `text` field |
+| `model` | string | Yes | The reranker model to use |
+
+#### **Response**
+- **200 OK**: Documents ranked by relevance.
+  ```json
+  {
+    "results": [
+      {"index": 0, "relevance_score": 0.95},
+      {"index": 1, "relevance_score": 0.12}
+    ]
+  }
+  ```
+
+- **400 Bad Request**: Missing or invalid parameters.
+  ```json
+  {
+    "error": "Missing required field: query"
+  }
+  ```
+
+#### **Example**
+```bash
+curl -X POST http://localhost:8080/api/rerank \
+-H "Content-Type: application/json" \
+-d '{
+  "query": "What is the capital of France?",
+  "documents": [
+    {"text": "Paris is the capital of France."},
+    {"text": "Berlin is the capital of Germany."}
+  ],
+  "model": "qwen3-reranker-0.6b"
+}'
+```
+
+---
+
+### **9. GET /**
 #### **Description**
 Displays a welcome message and a link to the GitHub project.
 

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -1,6 +1,16 @@
 # RKLLAMA Changelog
 
 
+## Unreleased (feat/rerank-logprobs-endpoint)
+
+### New Features
+- **Rerank Endpoint**: Added `/api/rerank` and `/v1/rerank` endpoints for logit-based cross-encoder scoring on the RK3588 NPU. Documents are truncated to 14,000 characters for optimal NPU speed.
+- **Per-model Locking**: Added `--preload model1,model2,model3` flag to preload multiple models at startup. Each model gets its own lock, enabling concurrent requests to different models without blocking.
+
+### Bug Fixes
+- **KV Cache Clearing**: Fixed critical performance regression where KV cache was not cleared after embed/rerank calls, causing response times to degrade from 0.3s to 26s per request. Cache is now cleared automatically after each call.
+
+
 ## Version 0.0.41 (Current)
 
 ### New Commands

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -69,7 +69,20 @@ python -m rkllama --config /path/to/config.ini
 
 # Set server section values
 python -m rkllama --server_port 8080 --server_debug
+
+# Preload multiple models for concurrent multi-model serving
+rkllama_server --preload model1,model2,model3
 ```
+
+### `--preload`
+
+Preloads one or more models into NPU memory at server startup. Each preloaded model gets its own lock, allowing concurrent requests to different models without blocking each other.
+
+```bash
+rkllama_server --preload qwen2.5:3b,qwen3-reranker-0.6b
+```
+
+This is useful when serving multiple models simultaneously (e.g., a chat model and a reranker) and you want requests to different models to be handled in parallel rather than sequentially.
 
 ## Using the Configuration API
 

--- a/src/rkllama/api/callback.py
+++ b/src/rkllama/api/callback.py
@@ -7,12 +7,13 @@ global_status = -1
 global_text = []
 split_byte_data = bytes(b"")
 last_embeddings = []
+last_logits = []
 global_metrics = []
 
 
 # Definir la fonction de rappel
 def callback_impl(result, userdata, status):
-    global split_byte_data, global_status, global_text, last_embeddings, global_metrics
+    global split_byte_data, global_status, global_text, last_embeddings, last_logits, global_metrics
 
     if status == LLMCallState.RKLLM_RUN_FINISH:
         global_status = status
@@ -95,7 +96,32 @@ def callback_impl(result, userdata, status):
                     # Send to the global variable
                     last_embeddings.append(embeddings)
                     print(f"\n✅ Embeddings Shape: {last_token_embedding.shape}")
-        
+
+            # --- LOGITS Part ---
+            if result and result.contents and result.contents.logits.logits and result.contents.logits.vocab_size > 0:
+                vocab_size = result.contents.logits.vocab_size
+                num_tokens = result.contents.logits.num_tokens
+
+                if vocab_size > 0:
+                    # Copy the logits array from C memory
+                    total_size = vocab_size * max(num_tokens, 1)
+                    array_type = ctypes.c_float * total_size
+                    raw = array_type.from_address(ctypes.addressof(result.contents.logits.logits.contents))
+                    logits_array = np.ctypeslib.as_array(raw).copy()
+
+                    # If multiple tokens, take the last token's logits
+                    if num_tokens > 1:
+                        logits_array = logits_array[(num_tokens - 1) * vocab_size : num_tokens * vocab_size]
+                    else:
+                        logits_array = logits_array[:vocab_size]
+
+                    last_logits.append({
+                        'logits': logits_array,
+                        'vocab_size': vocab_size,
+                        'num_tokens': num_tokens
+                    })
+                    print(f"\n✅ Logits captured: vocab_size={vocab_size}, num_tokens={num_tokens}")
+
         except Exception as e:
             print(f"\nError processing callback: {str(e)}", end='')
             

--- a/src/rkllama/api/image_generator.py
+++ b/src/rkllama/api/image_generator.py
@@ -179,26 +179,17 @@ class RKNN2Model:
         if not self.loaded:
             self.load_model()      
         
-       # Construct the list of input and transform them to Numpy if needed
+       # Construct the list of input and transform them to Numpy float32
+        # RKNN runtime only supports float32 — float64 inputs cause
+        # "E Unsupport inputs[0].dtype: float64" (fixes #113, #76)
         input_list = [value for key, value in kwargs.items()]
         input_list_np = []
         for i, input in enumerate(input_list):
-            print(
-                f"INPUT {i}: type={type(input)}, "
-                f"shape={None if not hasattr(input, 'shape') else input.shape}, "
-                f"dtype={getattr(input, 'dtype', None)}"
-            )
             if isinstance(input, np.ndarray):
-                input_np = input.astype(np.float32, copy=False) if np.issubdtype(input.dtype, np.floating) else input
-                input_list_np.append(input_np)
+                input_list_np.append(input.astype(np.float32, copy=False))
             else:
                 input_np = input.detach().cpu().numpy().astype(np.float32)
                 input_list_np.append(input_np)
-            print(
-                f"** TRANSFORMED** -> INPUT {i}: type={type(input_np)}, "
-                f"shape={None if not hasattr(input_np, 'shape') else input_np.shape}, "
-                f"dtype={getattr(input_np, 'dtype', None)}"
-            )
 
         # Call the RKNN model wit the input
         results = self.rknnlite.inference(inputs=input_list_np, data_format='nchw')

--- a/src/rkllama/api/server_utils.py
+++ b/src/rkllama/api/server_utils.py
@@ -6,6 +6,7 @@ import hashlib
 import base64
 import os
 import re  # Add import for regex used in JSON extraction
+import numpy as np
 import rkllama.api.variables as variables
 from transformers import AutoTokenizer
 from flask import jsonify, Response, stream_with_context
@@ -1073,10 +1074,14 @@ class GenerateImageEndpointHandler(EndpointHandler):
 
         # Send the task of generate image to the model
         image_list = variables.worker_manager_rkllm.generate_image(model_name, model_dir, prompt, size, num_images, seed, num_inference_steps, guidance_scale)
-        
+
+        # Check if image generation succeeded (fixes #76)
+        if image_list is None or len(image_list) == 0:
+            return jsonify({"error": f"Image generation failed for model '{model_name}'. Check server logs for details."}), 500
+
         # Calculate metrics
         metrics = cls.calculate_durations(start_time, prompt_eval_time)
-        
+
         # Format response
         response = cls.format_complete_response(image_list, model_name, model_dir, output_format, response_format, metrics)
 
@@ -1264,3 +1269,191 @@ class GenerateTranslationsEndpointHandler(EndpointHandler):
         
         # Return the translation text
         return translation_text
+
+
+# Cache for tokenizer yes/no token IDs per model
+_rerank_token_ids_cache = {}
+
+def _get_yes_no_token_ids(model_name):
+    """Get token IDs for 'yes' and 'no' from the model's tokenizer, cached per model."""
+    if model_name in _rerank_token_ids_cache:
+        return _rerank_token_ids_cache[model_name]
+
+    tokenizer = EndpointHandler.get_tokenizer(model_name)
+
+    # Try multiple variants to find the right token IDs
+    yes_candidates = ["yes", "Yes", "YES"]
+    no_candidates = ["no", "No", "NO"]
+
+    yes_id = None
+    no_id = None
+
+    for candidate in yes_candidates:
+        ids = tokenizer.encode(candidate, add_special_tokens=False)
+        if len(ids) == 1:
+            yes_id = ids[0]
+            break
+    if yes_id is None:
+        # Fallback: take first token of "yes"
+        ids = tokenizer.encode("yes", add_special_tokens=False)
+        yes_id = ids[0] if ids else None
+
+    for candidate in no_candidates:
+        ids = tokenizer.encode(candidate, add_special_tokens=False)
+        if len(ids) == 1:
+            no_id = ids[0]
+            break
+    if no_id is None:
+        ids = tokenizer.encode("no", add_special_tokens=False)
+        no_id = ids[0] if ids else None
+
+    logger.info(f"Rerank token IDs for model {model_name}: yes={yes_id}, no={no_id}")
+    _rerank_token_ids_cache[model_name] = (yes_id, no_id)
+    return yes_id, no_id
+
+
+def _format_rerank_prompt(query, document, task_instruction=None):
+    """Format a query-document pair as a Qwen3-Reranker cross-encoder prompt."""
+    if task_instruction is None:
+        task_instruction = "Given a web search query, retrieve relevant passages that answer the query"
+
+    prompt = (
+        "<|im_start|>system\n"
+        "Judge whether the Document is relevant to the Query. Answer only \"yes\" or \"no\".<|im_end|>\n"
+        "<|im_start|>user\n"
+        f"<Instruct>: {task_instruction}\n"
+        f"<Query>: {query}\n"
+        f"<Document>: {document}<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+    return prompt
+
+
+def _softmax_pair(logit_a, logit_b):
+    """Compute softmax over two logits and return probability of the first."""
+    max_val = max(logit_a, logit_b)
+    exp_a = np.exp(logit_a - max_val)
+    exp_b = np.exp(logit_b - max_val)
+    return float(exp_a / (exp_a + exp_b))
+
+
+class RerankEndpointHandler(EndpointHandler):
+    """Handler for /api/rerank endpoint requests"""
+
+    @staticmethod
+    def format_complete_response(model_name, results, metrics):
+        """Format the rerank response in Jina/Cohere-compatible format."""
+        response = {
+            "model": model_name,
+            "results": results,
+            "usage": {
+                "total_tokens": metrics.get("total_tokens", 0),
+            }
+        }
+        return response
+
+    @classmethod
+    def handle_request(cls, model_name, query, documents, top_n=None, options=None):
+        """Process a rerank request."""
+
+        if DEBUG_MODE:
+            logger.debug(f"RerankEndpointHandler: processing request for {model_name} with {len(documents)} documents")
+
+        # Get yes/no token IDs for scoring
+        yes_id, no_id = _get_yes_no_token_ids(model_name)
+
+        if yes_id is None or no_id is None:
+            return jsonify({"error": "Could not determine yes/no token IDs from tokenizer"}), 500
+
+        # Get optional task instruction
+        task_instruction = None
+        if options and isinstance(options, dict):
+            task_instruction = options.get("task_instruction", None)
+
+        results = []
+        total_tokens = 0
+        start_time = time.time()
+
+        for idx, doc in enumerate(documents):
+            # Handle documents that may be strings or dicts with a "text" field
+            if isinstance(doc, dict):
+                doc_text = doc.get("text", str(doc))
+            else:
+                doc_text = str(doc)
+
+            # Truncate document to fit within reranker context window.
+            # The prompt template + query use ~400 tokens (~1600 chars).
+            # With 4096 context, ~3600 tokens (~14400 chars) left for document.
+            MAX_DOC_CHARS = 14000
+            if len(doc_text) > MAX_DOC_CHARS:
+                doc_text = doc_text[:MAX_DOC_CHARS]
+
+            # Format the cross-encoder prompt
+            prompt = _format_rerank_prompt(query, doc_text, task_instruction)
+
+            # Send rerank task to the worker
+            variables.worker_manager_rkllm.rerank(model_name, prompt)
+
+            # Get the result
+            manager_pipe = variables.worker_manager_rkllm.get_result(model_name)
+
+            if manager_pipe.poll(int(rkllama.config.get("model", "max_seconds_waiting_worker_response"))):
+                logits_result = manager_pipe.recv()
+            else:
+                logger.error(f"Timeout waiting for rerank result for document {idx}")
+                # Return a low score on timeout
+                results.append({"index": idx, "relevance_score": 0.0})
+                continue
+
+            # Process the logits result
+            if isinstance(logits_result, dict) and "logits" in logits_result:
+                # We got actual logits - extract yes/no scores
+                logits_array = logits_result["logits"]
+                vocab_size = logits_result["vocab_size"]
+
+                if yes_id < vocab_size and no_id < vocab_size:
+                    logit_yes = float(logits_array[yes_id])
+                    logit_no = float(logits_array[no_id])
+                    score = _softmax_pair(logit_yes, logit_no)
+                else:
+                    logger.warning(f"Token IDs out of range: yes={yes_id}, no={no_id}, vocab_size={vocab_size}")
+                    score = 0.0
+
+                total_tokens += logits_result.get("num_tokens", 0)
+
+            elif isinstance(logits_result, dict) and "text_fallback" in logits_result:
+                # Fallback: parse text output
+                text = logits_result["text_fallback"].strip().lower()
+                if text.startswith("yes"):
+                    score = 1.0
+                elif text.startswith("no"):
+                    score = 0.0
+                else:
+                    # Ambiguous - assign a middle score
+                    logger.warning(f"Unexpected text output for rerank: '{text}'")
+                    score = 0.5
+            else:
+                logger.warning(f"Unexpected result type from rerank worker: {type(logits_result)}")
+                score = 0.0
+
+            results.append({
+                "index": idx,
+                "relevance_score": round(score, 6)
+            })
+
+        # Sort results by relevance_score descending
+        results.sort(key=lambda x: x["relevance_score"], reverse=True)
+
+        # Apply top_n filter if specified
+        if top_n is not None and isinstance(top_n, int) and top_n > 0:
+            results = results[:top_n]
+
+        # Calculate metrics
+        elapsed = time.time() - start_time
+        metrics = {
+            "total_tokens": total_tokens,
+            "total_duration_ms": int(elapsed * 1000),
+        }
+
+        response = cls.format_complete_response(model_name, results, metrics)
+        return jsonify(response), 200

--- a/src/rkllama/api/variables.py
+++ b/src/rkllama/api/variables.py
@@ -1,6 +1,9 @@
 import threading
+import logging
 from rkllama.config import is_debug_mode
 from rkllama.api.worker import WorkerManager
+
+logger = logging.getLogger("rkllama.variables")
 
 isLocked = False
 
@@ -8,7 +11,38 @@ isLocked = False
 worker_manager_rkllm = WorkerManager()
 
 
+# Legacy global lock - kept for backward compatibility with process.py
+# but should no longer be used directly. Use get_model_lock() instead.
 verrou = threading.Lock()
+
+# Per-model lock manager: each model gets its own lock so that
+# requests to different models can proceed concurrently.
+_model_locks = {}
+_model_locks_meta_lock = threading.Lock()  # protects _model_locks dict itself
+
+
+def get_model_lock(model_name: str) -> threading.Lock:
+    """
+    Return a per-model threading.Lock, creating one if it does not exist.
+    Requests to different models will use different locks and can run in parallel.
+    Requests to the same model will be serialized (RKLLM cannot handle concurrent
+    requests on the same model handle).
+    """
+    if model_name not in _model_locks:
+        with _model_locks_meta_lock:
+            # Double-check inside the meta lock
+            if model_name not in _model_locks:
+                _model_locks[model_name] = threading.Lock()
+                logger.debug(f"Created per-model lock for '{model_name}'")
+    return _model_locks[model_name]
+
+
+def remove_model_lock(model_name: str):
+    """
+    Remove the per-model lock when a model is unloaded.
+    """
+    with _model_locks_meta_lock:
+        _model_locks.pop(model_name, None)
 
 model_id = ""
 system = "Tu es un assistant artificiel."

--- a/src/rkllama/api/worker.py
+++ b/src/rkllama/api/worker.py
@@ -98,6 +98,7 @@ WORKER_TASK_GENERATE_IMAGE = "GENERATE_IMAGE"
 WORKER_TASK_GENERATE_SPEECH = "GENERATE_SPEECH"
 WORKER_TASK_GENERATE_TRANSCRIPTION = "GENERATE_TRANSCRIPTION"
 WORKER_TASK_GENERATE_TRANSLATION = "GENERATE_TRANSLATION"
+WORKER_TASK_RERANK = "RERANK"
 
 
 def run_encoder(model_input):
@@ -219,7 +220,7 @@ def run_rkllm_worker(name, worker_pipe, abort_flag, model_path, model_dir, optio
     _set_parent_death_signal()
 
     # Initialize individual callback for each worker to prevent error from RKLLM
-    from .callback import callback_impl, global_text, last_embeddings, global_metrics
+    from .callback import callback_impl, global_text, last_embeddings, last_logits, global_metrics
     from .rkllm import RKLLM
 
     # Connect the callback function between Python and C++ independently for each worker
@@ -323,18 +324,56 @@ def run_rkllm_worker(name, worker_pipe, abort_flag, model_path, model_dir, optio
                 # Run inference
                 thread_model = threading.Thread(target=model_rkllm.run, args=(inference_mode, model_input_type, model_input,))
                 thread_model.start()
-                
+
                 # Looping until execution of the thread finished
                 thread_finished = False
                 while not thread_finished:
-                    # Update status of the thread    
+                    # Update status of the thread
                     thread_model.join(timeout=0.005)
                     thread_finished = not thread_model.is_alive()
 
                 if last_embeddings:
                     # Send the embedding shapes of the input
-                    worker_pipe.send(last_embeddings[-1])  
-            
+                    worker_pipe.send(last_embeddings[-1])
+
+                # Clear KV cache after each embedding to prevent NPU performance degradation.
+                # Without this, repeated embedding requests accumulate KV state causing
+                # response times to degrade from ~1.5s to 26s+ over hours of operation.
+                try:
+                    model_rkllm.clear_cache()
+                except Exception:
+                    pass
+
+            elif task == WORKER_TASK_RERANK:
+                logger.info(f"Running rerank (get_logits) for model {name}...")
+                # Clear any previous logits
+                last_logits.clear()
+
+                # Run inference in GET_LOGITS mode
+                thread_model = threading.Thread(target=model_rkllm.run, args=(inference_mode, model_input_type, model_input,))
+                thread_model.start()
+
+                # Wait until execution of the thread finishes
+                thread_finished = False
+                while not thread_finished:
+                    thread_model.join(timeout=0.005)
+                    thread_finished = not thread_model.is_alive()
+
+                if last_logits:
+                    # Send the last logits result
+                    worker_pipe.send(last_logits[-1])
+                else:
+                    # Fallback: send text output for text-based scoring
+                    text_output = "".join(global_text)
+                    worker_pipe.send({"text_fallback": text_output})
+                    global_text.clear()
+
+                # Clear KV cache after each rerank to prevent NPU performance degradation
+                try:
+                    model_rkllm.clear_cache()
+                except Exception:
+                    pass
+
             elif task == WORKER_TASK_VISION_ENCODER:
                 logger.info(f"Running vision encoder for model {name}...")
                 # Run the vision encoder to get the image embedding
@@ -959,6 +998,13 @@ class WorkerManager:
         except Exception:
             pass  # variables module may not be fully initialized during shutdown
 
+            # Clean up per-model lock from variables module
+            try:
+                import rkllama.api.variables as variables
+                variables.remove_model_lock(model_name)
+            except Exception:
+                pass  # variables module may not be fully initialized during shutdown
+
     def stop_all(self):
         """
         Send a inference task to the corresponding model worker
@@ -1020,9 +1066,27 @@ class WorkerManager:
             model_input = (text_input, prompt_cache_file)
 
             # Send the inference task
-            self.send_task(model_name, (WORKER_TASK_EMBEDDING,RKLLMInferMode.RKLLM_INFER_GET_LAST_HIDDEN_LAYER, RKLLMInputType.RKLLM_INPUT_PROMPT, model_input))        
-            
-    
+            self.send_task(model_name, (WORKER_TASK_EMBEDDING,RKLLMInferMode.RKLLM_INFER_GET_LAST_HIDDEN_LAYER, RKLLMInputType.RKLLM_INPUT_PROMPT, model_input))
+
+
+    def rerank(self, model_name, prompt_input, prompt_cache_file=None):
+        """
+        Send a rerank task (get_logits mode) to the corresponding model worker
+
+        Args:
+            model_name (str): Model name to invoke
+            prompt_input (str): Formatted rerank prompt
+            prompt_cache_file (str): Prompt cache file (optional)
+        """
+        if model_name in self.workers.keys():
+
+            # Construct model input
+            model_input = (prompt_input, prompt_cache_file)
+
+            # Send the rerank task using GET_LOGITS inference mode
+            self.send_task(model_name, (WORKER_TASK_RERANK, RKLLMInferMode.RKLLM_INFER_GET_LOGITS, RKLLMInputType.RKLLM_INPUT_PROMPT, model_input))
+
+
     def multimodal(self, model_name, prompt_input, images, prompt_cache_file):
         """
         Send a inference task to the corresponding model worker for multimodal input

--- a/src/rkllama/server/server.py
+++ b/src/rkllama/server/server.py
@@ -435,6 +435,8 @@ def recevoir_message():
     # define modelfile path
     modelfile = os.path.join(modele_rkllm.model_dir, "Modelfile")
 
+    # Legacy endpoint: use global lock for backward compatibility since
+    # modele_rkllm is a single global model reference (not model-name based)
     variables.verrou.acquire()
     return Request(modele_rkllm, modelfile)
 
@@ -1069,10 +1071,11 @@ def generate_ollama():
             if error:
                 return jsonify({"error": f"Failed to load model '{model_name}': {error}"}), 500
         
-        # Acquire lock before processing
-        variables.verrou.acquire()
+        # Acquire per-model lock (allows different models to run concurrently)
+        model_lock = variables.get_model_lock(model_name)
+        model_lock.acquire()
         lock_acquired = True
-        
+
         # DIRECTLY use the GenerateEndpointHandler instead of the process_ollama_generate_request wrapper
         from rkllama.api.server_utils import GenerateEndpointHandler
         return GenerateEndpointHandler.handle_request(
@@ -1092,8 +1095,10 @@ def generate_ollama():
         return jsonify({"error": str(e)}), 500
     finally:
         # Only release if we acquired it
-        if lock_acquired and variables.verrou.locked():
-            variables.verrou.release()
+        if lock_acquired:
+            model_lock = variables.get_model_lock(model_name)
+            if model_lock.locked():
+                model_lock.release()
 
 
 # Also update the chat endpoint for consistency
@@ -1225,10 +1230,11 @@ def chat_ollama():
         #    rkllm_model_request.format_schema = format_spec
         #    rkllm_model_request.format_options = options
         
-        # Acquire lock before processing the request
-        variables.verrou.acquire()
+        # Acquire per-model lock (allows different models to run concurrently)
+        model_lock = variables.get_model_lock(model_name)
+        model_lock.acquire()
         lock_acquired = True  # Mark lock as acquired
-        
+
         # Create custom request for processing
         custom_req = type('obj', (object,), {
             'json': {
@@ -1269,10 +1275,12 @@ def chat_ollama():
     
     finally:
         # Only release if we acquired it
-        if lock_acquired and variables.verrou.locked():
-            if DEBUG_MODE:
-                logger.debug("Releasing lock in chat_ollama")
-            variables.verrou.release()
+        if lock_acquired:
+            model_lock = variables.get_model_lock(model_name)
+            if model_lock.locked():
+                if DEBUG_MODE:
+                    logger.debug(f"Releasing per-model lock for '{model_name}' in chat_ollama")
+                model_lock.release()
 
 
 # Only include debug endpoint if in debug mode
@@ -1339,9 +1347,11 @@ def embeddings_ollama():
             _, error = load_model(model_name, request_options=options)
             if error:
                 return jsonify({"error": f"Failed to load model '{model_name}': {error}"}), 500
-        variables.verrou.acquire()
+        # Acquire per-model lock (allows different models to run concurrently)
+        model_lock = variables.get_model_lock(model_name)
+        model_lock.acquire()
         lock_acquired = True
-        
+
         # DIRECTLY use the EmbedEndpointHandler instead of the process_ollama_generate_request wrapper
         from rkllama.api.server_utils import EmbedEndpointHandler
         return EmbedEndpointHandler.handle_request(
@@ -1358,8 +1368,70 @@ def embeddings_ollama():
         return jsonify({"error": str(e)}), 500
     finally:
         # Only release if we acquired it
-        if lock_acquired and variables.verrou.locked():
-            variables.verrou.release()
+        if lock_acquired:
+            model_lock = variables.get_model_lock(model_name)
+            if model_lock.locked():
+                model_lock.release()
+
+
+@app.route('/api/rerank', methods=['POST'])
+@app.route('/v1/rerank', methods=['POST'])
+def rerank():
+
+    lock_acquired = False  # Track lock status
+
+    try:
+        data = request.get_json(force=True)
+
+        model_name = data.get('model')
+        query = data.get('query')
+        documents = data.get('documents', [])
+        top_n = data.get('top_n', None)
+
+        if not model_name:
+            return jsonify({"error": "Missing model name"}), 400
+
+        if not query:
+            return jsonify({"error": "Missing query"}), 400
+
+        if not documents or not isinstance(documents, list):
+            return jsonify({"error": "Missing or invalid documents list"}), 400
+
+        # Remove possible namespace in model name
+        model_name = re.search(r'/(.*)', model_name).group(1) if re.search(r'/', model_name) else model_name
+
+        # Get all model options
+        options = data.get('options', {})
+        options = get_model_full_options(model_name, rkllama.config.get_path("models"), options)
+
+        # Load model if needed
+        if not variables.worker_manager_rkllm.exists_model_loaded(model_name):
+            _, error = load_model(model_name, request_options=options)
+            if error:
+                return jsonify({"error": f"Failed to load model '{model_name}': {error}"}), 500
+
+        # Acquire per-model lock (allows different models to run concurrently)
+        model_lock = variables.get_model_lock(model_name)
+        model_lock.acquire()
+        lock_acquired = True
+
+        from rkllama.api.server_utils import RerankEndpointHandler
+        return RerankEndpointHandler.handle_request(
+            model_name=model_name,
+            query=query,
+            documents=documents,
+            top_n=top_n,
+            options=options,
+        )
+    except Exception as e:
+        if DEBUG_MODE:
+            logger.exception(f"Error in rerank: {str(e)}")
+        return jsonify({"error": str(e)}), 500
+    finally:
+        if lock_acquired:
+            model_lock = variables.get_model_lock(model_name)
+            if model_lock.locked():
+                model_lock.release()
 
 
 # Version endpoint for Ollama API compatibility
@@ -1418,10 +1490,11 @@ def generate_image_openai():
         #    if error:
         #        return jsonify({"error": f"Failed to load model '{model_name}': {error}"}), 500
             
-        # Acquire lock before processing the request
-        variables.verrou.acquire()
+        # Acquire per-model lock (allows different models to run concurrently)
+        model_lock = variables.get_model_lock(model_name)
+        model_lock.acquire()
         lock_acquired = True  # Mark lock as acquired
-        
+
         # Process the request - this won't release the lock
         from rkllama.api.server_utils import GenerateImageEndpointHandler
         return GenerateImageEndpointHandler.handle_request(
@@ -1439,13 +1512,15 @@ def generate_image_openai():
     except Exception as e:
         logger.exception("Error in generate_image_openai")
         return jsonify({"error": str(e)}), 500
-    
+
     finally:
         # Only release if we acquired it
-        if lock_acquired and variables.verrou.locked():
-            if DEBUG_MODE:
-                logger.debug("Releasing lock in generate_image_openai")
-            variables.verrou.release()
+        if lock_acquired:
+            model_lock = variables.get_model_lock(model_name)
+            if model_lock.locked():
+                if DEBUG_MODE:
+                    logger.debug(f"Releasing per-model lock for '{model_name}' in generate_image_openai")
+                model_lock.release()
 
 
 # Default route
@@ -1494,10 +1569,11 @@ def generate_speech_openai():
             if error:
                 return jsonify({"error": f"Failed to load model '{model_name}': {error}"}), 500
         
-        # Acquire lock before processing the request
-        variables.verrou.acquire()
+        # Acquire per-model lock (allows different models to run concurrently)
+        model_lock = variables.get_model_lock(model_name)
+        model_lock.acquire()
         lock_acquired = True  # Mark lock as acquired
-        
+
         # Process the request - this won't release the lock
         from rkllama.api.server_utils import GenerateSpeechEndpointHandler
         return GenerateSpeechEndpointHandler.handle_request(
@@ -1511,13 +1587,15 @@ def generate_speech_openai():
     except Exception as e:
         logger.exception("Error in generate_speech_openai")
         return jsonify({"error": str(e)}), 500
-    
+
     finally:
         # Only release if we acquired it
-        if lock_acquired and variables.verrou.locked():
-            if DEBUG_MODE:
-                logger.debug("Releasing lock in generate_speech_openai")
-            variables.verrou.release()
+        if lock_acquired:
+            model_lock = variables.get_model_lock(model_name)
+            if model_lock.locked():
+                if DEBUG_MODE:
+                    logger.debug(f"Releasing per-model lock for '{model_name}' in generate_speech_openai")
+                model_lock.release()
 
 
 @app.route('/v1/audio/transcriptions', methods=['POST'])
@@ -1565,10 +1643,11 @@ def generate_transcriptions_openai():
             if error:
                 return jsonify({"error": f"Failed to load model '{model_name}': {error}"}), 500
             
-        # Acquire lock before processing the request
-        variables.verrou.acquire()
+        # Acquire per-model lock (allows different models to run concurrently)
+        model_lock = variables.get_model_lock(model_name)
+        model_lock.acquire()
         lock_acquired = True  # Mark lock as acquired
-        
+
         # Process the request - this won't release the lock
         from rkllama.api.server_utils import GenerateTranscriptionsEndpointHandler
         return GenerateTranscriptionsEndpointHandler.handle_request(
@@ -1581,13 +1660,15 @@ def generate_transcriptions_openai():
     except Exception as e:
         logger.exception("Error in generate_transcriptions_openai")
         return jsonify({"error": str(e)}), 500
-    
+
     finally:
         # Only release if we acquired it
-        if lock_acquired and variables.verrou.locked():
-            if DEBUG_MODE:
-                logger.debug("Releasing lock in generate_transcriptions_openai")
-            variables.verrou.release()
+        if lock_acquired:
+            model_lock = variables.get_model_lock(model_name)
+            if model_lock.locked():
+                if DEBUG_MODE:
+                    logger.debug(f"Releasing per-model lock for '{model_name}' in generate_transcriptions_openai")
+                model_lock.release()
 
 
 @app.route('/v1/audio/translations', methods=['POST'])
@@ -1624,10 +1705,11 @@ def generate_translations_openai():
             if error:
                 return jsonify({"error": f"Failed to load model '{model_name}': {error}"}), 500
             
-        # Acquire lock before processing the request
-        variables.verrou.acquire()
+        # Acquire per-model lock (allows different models to run concurrently)
+        model_lock = variables.get_model_lock(model_name)
+        model_lock.acquire()
         lock_acquired = True  # Mark lock as acquired
-        
+
         # Process the request - this won't release the lock
         from rkllama.api.server_utils import GenerateTranslationsEndpointHandler
         return GenerateTranslationsEndpointHandler.handle_request(
@@ -1639,13 +1721,15 @@ def generate_translations_openai():
     except Exception as e:
         logger.exception("Error in generate_translations_openai")
         return jsonify({"error": str(e)}), 500
-    
+
     finally:
         # Only release if we acquired it
-        if lock_acquired and variables.verrou.locked():
-            if DEBUG_MODE:
-                logger.debug("Releasing lock in generate_translations_openai")
-            variables.verrou.release()
+        if lock_acquired:
+            model_lock = variables.get_model_lock(model_name)
+            if model_lock.locked():
+                if DEBUG_MODE:
+                    logger.debug(f"Releasing per-model lock for '{model_name}' in generate_translations_openai")
+                model_lock.release()
 
 
 
@@ -1665,6 +1749,9 @@ def main():
     parser.add_argument('--port', type=str, help="Port for the server")
     parser.add_argument('--debug', action='store_true', help="Enable debug mode")
     parser.add_argument('--models', type=str, help="Path whe models will be loaded from")
+    parser.add_argument('--preload', type=str, default=None,
+                        help="Comma-separated model names to pre-load at startup (e.g. 'model-a,model-b,model-c'). "
+                             "Each model is pinned to its own NPU domain for concurrent serving.")
     args = parser.parse_args()
 
     # Load arguments into the config
@@ -1707,6 +1794,23 @@ def main():
     # Set the resource limits
     if os.getuid() == 0:
         resource.setrlimit(resource.RLIMIT_NOFILE, (102400, 102400))
+
+    # Pre-load models if --preload flag was provided
+    if args.preload:
+        preload_model_names = [name.strip() for name in args.preload.split(",") if name.strip()]
+        if preload_model_names:
+            print_color(f"Pre-loading {len(preload_model_names)} model(s): {', '.join(preload_model_names)}", "cyan")
+            for model_name in preload_model_names:
+                if variables.worker_manager_rkllm.exists_model_loaded(model_name):
+                    print_color(f"  Model '{model_name}' is already loaded, skipping.", "yellow")
+                    continue
+                print_color(f"  Loading model '{model_name}'...", "cyan")
+                _, error = load_model(model_name)
+                if error:
+                    print_color(f"  Failed to pre-load model '{model_name}': {error}", "red")
+                else:
+                    print_color(f"  Model '{model_name}' loaded successfully (domain_id={variables.worker_manager_rkllm.workers[model_name].worker_model_info.base_domain_id})", "green")
+            print_color(f"Pre-load complete. {len(variables.worker_manager_rkllm.workers)} model(s) active.", "green")
 
     # Start the API server with the chosen port
     print_color(f"Start the API at http://localhost:{port}", "blue")


### PR DESCRIPTION
## Summary

Adds cross-encoder reranking, concurrent multi-model serving, and fixes critical NPU performance and image generation issues.

Replaces #138 which was closed during a branch cleanup.

## Changes

### /api/rerank endpoint
- `POST /api/rerank` and `POST /v1/rerank` — logit-based cross-encoder scoring
- Uses softmax over yes/no token probabilities for accurate relevance scores
- Works with Qwen3-Reranker-0.6B on RK3588 NPU

### Per-model locking + --preload
- `--preload model1,model2,model3` flag for concurrent multi-model NPU serving
- Each model gets its own lock — concurrent requests to different models don't block

### KV cache fix
- Clear KV cache after each embed/rerank operation
- Without this, performance degrades from 0.3s to 26s+ over hours

### Image generation fix (#76, #113)
- Cast all numpy inputs to float32 — RKNN runtime only supports float32
- Added None checking in handle_complete — returns proper 500 error instead of crash

### Documentation
- Reranking section in README with API examples
- Per-model locking and --preload in configuration docs
- Changelog updated

## Testing

Running in production on Orange Pi 5 Plus (RK3588, 16GB) with 3 preloaded models, stable over days of continuous operation.

See discussion and review on the previous PR: #138