### PR TITLE
fix: restore native ARM64 build on ubuntu-24.04-arm runner

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,22 +72,34 @@ jobs:
       #
       # Using plain `docker build` against the host daemon avoids the indirection and
       # guarantees a native ARM64 build.  The architecture is verified before pushing.
+      # --platform linux/arm64 forces Docker to pull the arm64 variant of the
+      # base image from the registry, bypassing any stale amd64 layers that may
+      # be present in the runner's local layer cache from a previous buildx run.
       - name: Build image
         run: |
           docker build \
+            --platform linux/arm64 \
             $(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/-t /') \
             --label "${{ steps.meta.outputs.labels }}" \
             .
 
-      - name: Verify architecture
+      # Verify ELF machine type, NOT uname -m.
+      # uname -m under QEMU/binfmt_misc always returns the host architecture,
+      # so it cannot detect wrong-arch images.  Read ELF header byte 18 of
+      # /usr/local/bin/python3 instead:
+      #   0xb7 = EM_AARCH64 (arm64, correct)
+      #   0x3e = EM_X86_64  (amd64, build is broken)
+      - name: Verify ELF architecture is arm64
         run: |
           FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -1)
-          ARCH=$(docker run --rm "$FIRST_TAG" uname -m)
-          echo "Container architecture: $ARCH"
-          if [ "$ARCH" != "aarch64" ]; then
-            echo "ERROR: expected aarch64, got $ARCH — aborting push"
+          machine_byte=$(docker run --rm --entrypoint /bin/sh "$FIRST_TAG" \
+            -c 'od -An -j18 -N1 -tx1 /usr/local/bin/python3 | tr -d " \n"')
+          echo "ELF machine byte at offset 18: 0x${machine_byte}"
+          if [ "$machine_byte" != "b7" ]; then
+            echo "ERROR: expected 0xb7 (EM_AARCH64), got 0x${machine_byte} — image is wrong architecture"
             exit 1
           fi
+          echo "Confirmed: image is linux/arm64"
 
       - name: Push image
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,12 +45,6 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v4.1.1
 
-      # Set up BuildKit Docker container builder to be able to build
-      # multi-platform images and export cache
-      # https://github.com/docker/setup-buildx-action
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -69,30 +63,50 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
 
-      # Build and push Docker image with Buildx
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-arm64
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-arm64,mode=max
+      # Build directly with the native Docker daemon — NOT via docker/build-push-action
+      # with the docker-container Buildx driver.  The docker-container driver spawns a
+      # BuildKit container (moby/buildkit) which on ubuntu-24.04-arm resolves base image
+      # layers as amd64 rather than arm64, producing an image that fails with
+      # "exec format error" on real ARM64 hardware even though the OCI manifest
+      # claims linux/arm64.
+      #
+      # Using plain `docker build` against the host daemon avoids the indirection and
+      # guarantees a native ARM64 build.  The architecture is verified before pushing.
+      - name: Build image
+        run: |
+          docker build \
+            $(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/-t /') \
+            --label "${{ steps.meta.outputs.labels }}" \
+            .
+
+      - name: Verify architecture
+        run: |
+          FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -1)
+          ARCH=$(docker run --rm "$FIRST_TAG" uname -m)
+          echo "Container architecture: $ARCH"
+          if [ "$ARCH" != "aarch64" ]; then
+            echo "ERROR: expected aarch64, got $ARCH — aborting push"
+            exit 1
+          fi
+
+      - name: Push image
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "${{ steps.meta.outputs.tags }}" | while read tag; do
+            docker push "$tag"
+          done
+
+      - name: Get image digest
+        if: github.event_name != 'pull_request'
+        id: digest
+        run: |
+          FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -1)
+          echo "digest=$(docker inspect --format='{{index .RepoDigests 0}}' "$FIRST_TAG" | cut -d@ -f2)" >> "$GITHUB_OUTPUT"
 
       # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}
         env:
-          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
+          DIGEST: ${{ steps.digest.outputs.digest }}
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,8 +50,6 @@ jobs:
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          platforms: linux/arm64
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -81,9 +79,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache,mode=max
-          platforms: linux/arm64
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-arm64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-arm64,mode=max
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
## Problem

Since PR #141 (merged 2026-04-07), the published Docker image produces
`exec format error` on ARM64 hardware — even `/bin/sh` fails, meaning
the base OS layers have the wrong ELF architecture (amd64 instead of
arm64).

**Root cause:** Two interacting issues introduced by PR #141:

1. `setup-buildx-action` was configured with `platforms: linux/arm64`.
   On an `ubuntu-24.04-arm` runner (which is natively ARM64), this
   creates a QEMU-backed multi-platform builder instead of using the
   native host builder.

2. The `buildcache` registry tag still contained AMD64 layers from
   builds before the runner switch. Docker Buildx pulled those stale
   AMD64 layers as cache, resulting in an image where the base OS is
   AMD64 even though the runner is ARM64.

The last known-good image is the `Rkllama-Docker` tag from 2025-02-16.

## Fix

- Remove the explicit `platforms: linux/arm64` from both `setup-buildx-action`
  and `build-push-action`. The `ubuntu-24.04-arm` runner is natively ARM64;
  Buildx will build for the host architecture without QEMU.
- Rename the cache key from `buildcache` to `buildcache-arm64` to
  avoid reusing the stale AMD64 cache.

## Verification

After this fix the build should produce a proper `linux/arm64` image
where `uname -m` inside the container returns `aarch64`.