### PR TITLE
fix: ubuntu:24.04 base image + remove platforms: flag to fix ARM64 on RK3588

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Normalize image name to lowercase
         run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> $GITHUB_ENV
@@ -30,19 +30,20 @@ jobs:
 
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4.1.1
 
       # Do NOT set `platforms:` here — on a native ubuntu-24.04-arm runner,
-      # specifying platforms: linux/arm64 forces a QEMU-backed docker-container
-      # builder instead of using the host builder, which can contaminate the
-      # layer cache with amd64 layers from previous builds.  Omitting the flag
-      # lets Buildx default to the host architecture (arm64).
+      # specifying platforms: linux/arm64 forces QEMU-backed cross-compilation
+      # even though the runner is natively arm64.  This causes the docker-container
+      # builder to pull and cache amd64 base layers, contaminating subsequent
+      # arm64 builds.  Omitting the flag lets Buildx build for the runner's
+      # native architecture without QEMU.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -50,7 +51,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,24 +1,15 @@
 name: Docker
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
   push:
     branches: [ "main", "Rkllama-Docker" ]
-    # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
-
 
 jobs:
   build:
@@ -26,76 +17,60 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Normalize image name to lowercase
         run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> $GITHUB_ENV
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@v3
 
-      # Set up BuildKit Docker container builder to be able to build
-      # multi-platform images and export cache
-      # https://github.com/docker/setup-buildx-action
+      # Do NOT set `platforms:` here — on a native ubuntu-24.04-arm runner,
+      # specifying platforms: linux/arm64 forces a QEMU-backed docker-container
+      # builder instead of using the host builder, which can contaminate the
+      # layer cache with amd64 layers from previous builds.  Omitting the flag
+      # lets Buildx default to the host architecture (arm64).
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          platforms: linux/arm64
+        uses: docker/setup-buildx-action@v3
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
 
-      # Build and push Docker image with Buildx
-      # https://github.com/docker/build-push-action
+      # Do NOT set `platforms:` on build-push-action — same reason as above.
+      # Use a cache key suffix (-arm64) to avoid reusing the stale amd64 cache
+      # that existed before the runner switch to ubuntu-24.04-arm.
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache,mode=max
-          platforms: linux/arm64
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-arm64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-arm64,mode=max
 
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}
         env:
-          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,15 +1,24 @@
 name: Docker
 
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
 on:
   push:
     branches: [ "main", "Rkllama-Docker" ]
+    # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
 
 env:
+  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
+
 
 jobs:
   build:
@@ -17,6 +26,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
       id-token: write
 
     steps:
@@ -28,19 +39,26 @@ jobs:
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
 
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v4.1.1
 
-      # Do NOT set `platforms:` here — on a native ubuntu-24.04-arm runner,
-      # specifying platforms: linux/arm64 forces QEMU-backed cross-compilation
-      # even though the runner is natively arm64.  This causes the docker-container
-      # builder to pull and cache amd64 base layers, contaminating subsequent
-      # arm64 builds.  Omitting the flag lets Buildx build for the runner's
-      # native architecture without QEMU.
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      #
+      # NOTE: Do NOT set `platforms: linux/arm64` here — on a native
+      # ubuntu-24.04-arm runner this forces QEMU-backed cross-compilation
+      # even though the runner is natively arm64, causing the docker-container
+      # builder to pull and cache amd64 base layers and contaminate subsequent
+      # arm64 builds.  Omitting the flag builds for the runner's native arch.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
@@ -49,18 +67,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
 
-      # Do NOT set `platforms:` on build-push-action — same reason as above.
-      # Use a cache key suffix (-arm64) to avoid reusing the stale amd64 cache
-      # that existed before the runner switch to ubuntu-24.04-arm.
+      # Build and push Docker image with Buildx
+      # https://github.com/docker/build-push-action
+      #
+      # NOTE: Do NOT set `platforms: linux/arm64` here — same reason as above.
+      # The cache key uses the -arm64 suffix to avoid reusing the stale amd64
+      # cache that existed before the runner switch to ubuntu-24.04-arm.
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -69,9 +92,17 @@ jobs:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-arm64
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-arm64,mode=max
 
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}
         env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,27 @@
-FROM python:3.12-slim
+FROM ubuntu:24.04
+
+# RK3588 (Cortex-A76/A55) is ARMv8.2-A — it does NOT support Pointer
+# Authentication (PAC, ARMv8.3-A).  Debian Trixie ARM64 packages
+# (python:3.12-slim) are compiled with PAC guards; the kernel returns
+# ENOEXEC for those binaries on RK3588, causing "exec format error" at
+# container startup.  Ubuntu 24.04 ARM64 packages do NOT use PAC and
+# run correctly on ARMv8.2-A hardware.
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libgomp1 wget curl sudo git build-essential \
-    && apt-get install -y ffmpeg libsm6 libxext6 \
+    && apt-get install -y --no-install-recommends \
+       python3.12 python3.12-dev python3-pip python3.12-venv \
+       libgomp1 wget curl sudo git build-essential \
+       ffmpeg libsm6 libxext6 \
     && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
-# Fix setupttols version to prevent error: No module named 'pkg_resources' 
-RUN python -m pip --no-cache-dir install "setuptools<82.0.0"
+# Use a virtual environment to avoid Ubuntu 24.04's PEP 668
+# "externally-managed-environment" restriction.
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir "setuptools<82.0.0"
 
 WORKDIR /opt/rkllama
 
@@ -18,13 +33,13 @@ RUN chmod 755 /usr/lib/librkllmrt.so && ldconfig
 COPY ./src/rkllama/lib/librknnrt.so /usr/lib/
 RUN chmod 755 /usr/lib/librknnrt.so && ldconfig
 
-# Copy the source and other resourvces of the RKllama project
+# Copy the source and other resources of the RKllama project
 COPY ./src /opt/rkllama/src
 RUN mkdir /opt/rkllama/models
 COPY README.md LICENSE pyproject.toml /opt/rkllama/
 
-# Install RKLlama project
-RUN python -m pip --no-cache-dir install .
+# Install RKllama project
+RUN pip install --no-cache-dir .
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Problems fixed

Two separate issues combined to make the published image unusable on RK3588 hardware since PR #141.

### 1. BuildKit cache contamination (CI workflow)

`setup-buildx-action` with `platforms: linux/arm64` on a native `ubuntu-24.04-arm` runner forces a **QEMU-backed docker-container builder** instead of using the host builder. This builder shares a layer cache namespace with amd64 builds. The old `:buildcache` registry tag still contained amd64 base OS layers, so subsequent arm64 builds pulled those stale layers — producing an image where `/bin/sh` and the entire base OS are amd64 ELF, causing `exec format error` at container startup.

**Fix:** Remove `platforms: linux/arm64` from both `setup-buildx-action` and `build-push-action`. On a native arm64 runner, omitting the flag builds for the host architecture without QEMU. Rename the cache key to `:buildcache-arm64` to avoid reusing the poisoned cache.

### 2. Pointer Authentication (PAC) incompatibility with Debian base (Dockerfile)

Even with a correctly built arm64 image, `python:3.12-slim` (Debian Trixie) **cannot run on RK3588**. Debian Trixie ARM64 packages are compiled with [Pointer Authentication (PAC)](https://developer.arm.com/documentation/den0024/a/The-AArch64-Processor/Pointer-authentication), an ARMv8.3-A feature. The RK3588 SoC (Cortex-A76 + Cortex-A55) implements **ARMv8.2-A only** — it has no PAC hardware. The Linux kernel returns `ENOEXEC` when attempting to execute a PAC-guarded ELF binary on hardware without PAC support, which is why `/usr/bin/python3.12` and even `/bin/sh` immediately crash.

Ubuntu 24.04 ARM64 packages are **not** compiled with PAC and run correctly on ARMv8.2-A hardware including RK3588, RK3568, and other Rockchip SoCs.

**Fix:** Change `FROM python:3.12-slim` → `FROM ubuntu:24.04`. Install Python 3.12 from Ubuntu apt packages. Use a `venv` to work around Ubuntu 24.04's PEP 668 pip restriction.

## Verification

After this fix the image must:
- Have ELF machine byte 0xb7 (EM_AARCH64) for all binaries: `od -An -j18 -N1 -tx1 /usr/bin/python3.12`
- Start `rkllama_server` without `exec format error` on RK3588 hardware
- Load and serve RKLLM models

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | `FROM ubuntu:24.04` instead of `python:3.12-slim`; add venv; install Python from apt |
| `.github/workflows/docker-publish.yml` | Remove `platforms: linux/arm64` from both Buildx steps; rename cache key to `:buildcache-arm64` |