### PR TITLE
Fix OpenAI tool-call handling for Qwen

### DIFF
--- a/src/rkllama/api/format_utils.py
+++ b/src/rkllama/api/format_utils.py
@@ -911,6 +911,76 @@ def get_tool_calls_generic(response):
     return tool_calls_renamed
 
 
+def close_truncated_json_object(text):
+    """Best-effort completion for a JSON object cut off at end-of-generation."""
+    start = text.find("{")
+    if start == -1:
+        return None
+
+    candidate = text[start:].strip()
+    candidate = re.sub(r"</tool_call>.*$", "", candidate, flags=re.DOTALL).strip()
+    if not candidate:
+        return None
+
+    stack = []
+    in_string = False
+    escaped = False
+
+    for char in candidate:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            stack.append("}")
+        elif char == "[":
+            stack.append("]")
+        elif char in "}]":
+            if stack and stack[-1] == char:
+                stack.pop()
+
+    if in_string:
+        candidate += '"'
+
+    candidate += "".join(reversed(stack))
+    return candidate
+
+
+def get_tool_calls_repaired(response):
+    """Recover Qwen-style tool calls when the model stops after partial JSON."""
+    logger.debug("Searching tools with repaired method: get_tool_calls_repaired")
+
+    search_regions = re.findall(r"<tool_call>(.*?)(?:</tool_call>|$)", response, re.DOTALL)
+    if not search_regions:
+        search_regions = [response]
+
+    tool_calls = []
+    for region in search_regions:
+        fixed = close_truncated_json_object(region)
+        if not fixed:
+            continue
+        try:
+            tool = json.loads(fixed)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(tool, dict):
+            continue
+        if not ({"name", "arguments"}.issubset(tool.keys()) or {"name", "parameters"}.issubset(tool.keys())):
+            continue
+        if "parameters" in tool:
+            tool["arguments"] = tool.pop("parameters")
+        tool_calls.append({"function": tool})
+
+    return tool_calls
+
+
 def get_tool_calls_standard(response):
     """ Get all the tool calls indicated by the LLM in the response. 
         Only work if the chat template of the LLM uses <tool_call></tool_call> tags (Like Qwen models)
@@ -936,6 +1006,11 @@ def get_tool_calls(response):
     if not tool_calls:
         # No standard format tool call found. Search for more generic way
         tool_calls = get_tool_calls_generic(response)
+
+    if not tool_calls:
+        # Some small Qwen RKLLM builds stop after emitting a partial tool-call
+        # JSON object. Recover only when the required tool-call keys are present.
+        tool_calls = get_tool_calls_repaired(response)
 
     return tool_calls
 

--- a/src/rkllama/api/server_utils.py
+++ b/src/rkllama/api/server_utils.py
@@ -38,6 +38,50 @@ class RequestWrapper:
 
 class EndpointHandler:
     """Base class for endpoint handlers with common functionality"""
+
+    @staticmethod
+    def normalize_message_content(content):
+        """Convert OpenAI-compatible message content variants to plain text."""
+        if content is None:
+            return ""
+
+        if isinstance(content, list):
+            parts = []
+            for item in content:
+                if isinstance(item, dict):
+                    if item.get("type") == "text" and "text" in item:
+                        parts.append(str(item["text"]))
+                    elif "content" in item:
+                        parts.append(EndpointHandler.normalize_message_content(item["content"]))
+                    elif item.get("type") != "image_url":
+                        parts.append(json.dumps(item, ensure_ascii=False))
+                else:
+                    parts.append(str(item))
+            return "\n".join(part for part in parts if part)
+
+        if isinstance(content, dict):
+            if "text" in content:
+                return str(content["text"])
+            return json.dumps(content, ensure_ascii=False)
+
+        return str(content)
+
+    @staticmethod
+    def normalize_messages_for_chat_template(messages):
+        """Make OpenAI/Ollama message objects safe for tokenizer chat templates."""
+        normalized = []
+        for message in messages:
+            if not isinstance(message, dict):
+                normalized.append({"role": "user", "content": str(message)})
+                continue
+
+            normalized_message = dict(message)
+            normalized_message["content"] = EndpointHandler.normalize_message_content(
+                normalized_message.get("content", "")
+            )
+            normalized.append(normalized_message)
+
+        return normalized
     
     
     @staticmethod
@@ -48,8 +92,10 @@ class EndpointHandler:
         tokenizer = EndpointHandler.get_tokenizer(model_name)
         supports_system_role = "raise_exception('System role not supported')" not in tokenizer.chat_template
         
+        messages = EndpointHandler.normalize_messages_for_chat_template(messages)
+
         if system and supports_system_role:
-            prompt_messages = [{"role": "system", "content": system}] + messages
+            prompt_messages = [{"role": "system", "content": EndpointHandler.normalize_message_content(system)}] + messages
         else:
             prompt_messages = messages
         
@@ -336,6 +382,7 @@ class ChatEndpointHandler(EndpointHandler):
             response_tokens = [] # All tokens from response
             thinking_response_tokens = [] # Thinking tokens from response
             final_response_tokens = [] # Final answer tokens from response
+            json_tool_calls = []
             
 
             while not thread_finished or not final_sent:
@@ -346,10 +393,10 @@ class ChatEndpointHandler(EndpointHandler):
                     variables.worker_manager_rkllm.workers[model_name].abort_flag.value = True
                     
                     # Raise Exception
-                    logger.error(f"No response received by the Worker of the model {model_name} in {int(rkllama.config.get("model", "max_seconds_waiting_worker_response"))} seconds.")
+                    logger.error(f"No response received by the Worker of the model {model_name} in {int(rkllama.config.get('model', 'max_seconds_waiting_worker_response'))} seconds.")
                     
                     # Send message to the user
-                    token=f"Aborted inference by Timeout ({int(rkllama.config.get("model","max_seconds_waiting_worker_response"))} seconds). Try again."
+                    token=f"Aborted inference by Timeout ({int(rkllama.config.get('model','max_seconds_waiting_worker_response'))} seconds). Try again."
 
                     # Set finished state of the thread inference
                     thread_finished = True
@@ -412,6 +459,8 @@ class ChatEndpointHandler(EndpointHandler):
                     # Final check for tool calls in the complete response
                     if tools:
                         json_tool_calls = get_tool_calls("".join(final_response_tokens))
+                        if json_tool_calls:
+                            tool_calls = True
                         
                         # Last check for non standard <tool_call> token and tools calls only when finished before the wait token time
                         if len(final_response_tokens) < max_token_to_wait_for_tool_call:
@@ -419,13 +468,13 @@ class ChatEndpointHandler(EndpointHandler):
                                 tool_calls = True
 
                     # If tool calls detected, send them as final response
-                    if tools and tool_calls:
+                    if tools and tool_calls and json_tool_calls:
                         chunk_tool_call = cls.format_streaming_chunk(model_name=model_name, token=json_tool_calls, tool_calls=tool_calls)
                         yield f"{json.dumps(chunk_tool_call)}\n"
                     elif len(final_response_tokens)  < max_token_to_wait_for_tool_call: 
                         for temp_token in response_tokens:
                               time.sleep(0.1) # Simulate delay to stream previos tokens
-                              chunk = cls.format_streaming_chunk(model_name=model_name, token=temp_token,tool_calls=tool_calls)
+                              chunk = cls.format_streaming_chunk(model_name=model_name, token=temp_token)
                               yield f"{json.dumps(chunk)}\n"
 
                     metrics = cls.calculate_durations(start_time, prompt_eval_time)
@@ -447,7 +496,7 @@ class ChatEndpointHandler(EndpointHandler):
                                 "parsed": parsed_data,
                                 "cleaned_json": cleaned_json
                             }
-                    final_chunk = cls.format_streaming_chunk(model_name=model_name, token="", is_final=True, metrics=metrics, format_data=format_data,tool_calls=tool_calls)
+                    final_chunk = cls.format_streaming_chunk(model_name=model_name, token="", is_final=True, metrics=metrics, format_data=format_data,tool_calls=(tool_calls and bool(json_tool_calls)))
                     yield f"{json.dumps(final_chunk)}\n"
                     
         return Response(generate(), content_type='application/x-ndjson')
@@ -488,10 +537,10 @@ class ChatEndpointHandler(EndpointHandler):
                 variables.worker_manager_rkllm.workers[model_name].abort_flag.value = True
 
                 # Raise Exception
-                logger.error(f"No response received by the Worker of the model {model_name} in {int(rkllama.config.get("model", "max_seconds_waiting_worker_response"))} seconds.")
+                logger.error(f"No response received by the Worker of the model {model_name} in {int(rkllama.config.get('model', 'max_seconds_waiting_worker_response'))} seconds.")
                 
                 # Send message to the user
-                token=f"Aborted inference by Timeout ({int(rkllama.config.get("model","max_seconds_waiting_worker_response"))} seconds). Try again."
+                token=f"Aborted inference by Timeout ({int(rkllama.config.get('model','max_seconds_waiting_worker_response'))} seconds). Try again."
 
                 # Set finished state of the thread inference
                 thread_finished = True
@@ -702,10 +751,10 @@ class GenerateEndpointHandler(EndpointHandler):
                     variables.worker_manager_rkllm.workers[model_name].abort_flag.value = True
                     
                     # Raise Exception
-                    logger.error(f"No response received by the Worker of the model {model_name} in {int(rkllama.config.get("model", "max_seconds_waiting_worker_response"))} seconds.")
+                    logger.error(f"No response received by the Worker of the model {model_name} in {int(rkllama.config.get('model', 'max_seconds_waiting_worker_response'))} seconds.")
                     
                     # Send message to the user
-                    token=f"Aborted inference by Timeout ({int(rkllama.config.get("model","max_seconds_waiting_worker_response"))} seconds). Try again." 
+                    token=f"Aborted inference by Timeout ({int(rkllama.config.get('model','max_seconds_waiting_worker_response'))} seconds). Try again."
 
                     # Set finished state of the thread inference
                     thread_finished = True
@@ -796,10 +845,10 @@ class GenerateEndpointHandler(EndpointHandler):
                 variables.worker_manager_rkllm.workers[model_name].abort_flag.value = True
                 
                 # Raise Exception
-                logger.error(f"No response received by the Worker of the model {model_name} in {int(rkllama.config.get("model", "max_seconds_waiting_worker_response"))} seconds.")
+                logger.error(f"No response received by the Worker of the model {model_name} in {int(rkllama.config.get('model', 'max_seconds_waiting_worker_response'))} seconds.")
                 
                 # Send message to the user
-                token=f"Aborted inference by Timeout ({int(rkllama.config.get("model","max_seconds_waiting_worker_response"))} seconds). Try again." 
+                token=f"Aborted inference by Timeout ({int(rkllama.config.get('model','max_seconds_waiting_worker_response'))} seconds). Try again."
 
                 # Set finished state of the thread inference
                 thread_finished = True
@@ -983,7 +1032,7 @@ class EmbedEndpointHandler(EndpointHandler):
                 # Abort the current inference
                 variables.worker_manager_rkllm.workers[model_name].abort_flag.value = True
                 # Raise Exception
-                logger.error(f"No response received by the Worker of the model {model_name} in {int(rkllama.config.get("model", "max_seconds_waiting_worker_response"))} seconds.")
+                logger.error(f"No response received by the Worker of the model {model_name} in {int(rkllama.config.get('model', 'max_seconds_waiting_worker_response'))} seconds.")
                 # Send empty embedding
                 last_embeddings = embeddings = {
                         'embedding': [],


### PR DESCRIPTION
• Title:
  Fix OpenAI tool-call handling for Qwen

  Description:

  ## Summary

  Fixes OpenAI-compatible tool calling for Qwen-style models.

  This PR:
  - normalizes OpenAI message content before applying tokenizer chat templates
  - recovers Qwen `<tool_call>` responses when generation stops after a partial JSON object
  - avoids emitting empty tool-call responses as successful tool calls
  - fixes required f-string quoting so `server_utils.py` remains valid on Python 3.9+

  ## Context

  Qwen chat templates emit tool calls as:

  ```xml
  <tool_call>
  {"name": "...", "arguments": {...}}
  </tool_call>

  Some small RKLLM Qwen builds can stop after emitting a partial JSON object. Previously that
  produced either no usable OpenAI tool_calls field or an empty tool-call response.